### PR TITLE
IpHelper::getCidrBits() enh #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,7 @@ echo IpHelper::expandIPv6('2001:db8::1');
 
 // converting IP to bits representation
 echo IpHelper::ip2bin('192.168.1.1');
+
+// gets bits from CIDR Notation
+echo IpHelper::getCidrBits('192.168.1.21/32');
 ```

--- a/src/IpHelper.php
+++ b/src/IpHelper.php
@@ -117,4 +117,30 @@ class IpHelper
         }
         return $result;
     }
+
+    /**
+     * Gets the bits from CIDR Notation.
+     *
+     * @param string $ip IP or IP with CIDR Notation (`127.0.0.1`, `2001:db8:a::123/64`)
+     */
+    public static function getCidrBits(string $ip): int
+    {
+        if (preg_match('/^(?<ip>.{2,}?)(?:\/(?<bits>-?\d+))?$/', $ip, $matches) === 0) {
+            throw new \InvalidArgumentException("Unrecognized address $ip!", 1);
+        }
+        $ipVersion = static::getIpVersion($matches['ip']);
+        $maxBits = $ipVersion === self::IPV6 ? self::IPV6_ADDRESS_LENGTH : self::IPV4_ADDRESS_LENGTH;
+        $bits = $matches['bits'] ?? null;
+        if ($bits === null) {
+            return $maxBits;
+        }
+        $bits = (int)$bits;
+        if ($bits < 0) {
+            throw new \InvalidArgumentException('The number of CIDR bits cannot be negative!', 2);
+        }
+        if ($bits > $maxBits) {
+            throw new \InvalidArgumentException("CIDR bits is greater than $bits!", 3);
+        }
+        return $bits;
+    }
 }

--- a/src/IpHelper.php
+++ b/src/IpHelper.php
@@ -106,7 +106,7 @@ class IpHelper
         if (static::getIpVersion($ip) === self::IPV4) {
             $ipBinary = pack('N', ip2long($ip));
         } elseif (@inet_pton('::1') === false) {
-            throw new \InvalidArgumentException('IPv6 is not supported by inet_pton()!');
+            throw new \RuntimeException('IPv6 is not supported by inet_pton()!');
         } else {
             $ipBinary = inet_pton($ip);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #6 
| Depend on | #4 

I see less sense in the check method as the getter itself checks.
The invalid IP test does not work properly because it depends on #4.
